### PR TITLE
RM bad @match

### DIFF
--- a/main.user.js
+++ b/main.user.js
@@ -10,7 +10,6 @@
 // @match        https://www.smashcast.tv/*
 // @match        https://mixer.com/*
 // @match        http://www.bigo.tv/*
-// @match        play.afreecatv.com/*
 // @match        https://www.huya.com/*
 // @match        https://instagib.tv/*
 // @match        https://live.bilibili.com/*


### PR DESCRIPTION
I couldn't get greasemonkey to install it without this change...

Noobily removes // @match        play.afreecatv.com/*
because greasemonkey doesn't like this line. It probably needs the proper http prefix or something